### PR TITLE
Added some missing StripeTaxIDTypes

### DIFF
--- a/Sources/StripeKit/Billing/Customer Tax IDs/TaxID.swift
+++ b/Sources/StripeKit/Billing/Customer Tax IDs/TaxID.swift
@@ -30,9 +30,14 @@ public struct StripeTaxID: StripeModel {
 }
 
 public enum StripeTaxIDType: String, StripeModel {
-    case euVat = "eu_vat"
-    case nzGst = "nz_gst"
     case auAbn = "au_abn"
+    case chVat = "ch_vat"
+    case euVat = "eu_vat"
+    case inGst = "in_gst"
+    case mxRfc = "mx_rfc"
+    case noVat = "no_vat"
+    case nzGst = "nz_gst"
+    case zaVat = "za_vat"
     case unknown
 }
 

--- a/Sources/StripeKit/Core Resources/Customers/Customer.swift
+++ b/Sources/StripeKit/Core Resources/Customers/Customer.swift
@@ -23,7 +23,8 @@ public struct StripeCustomer: StripeModel {
     /// Three-letter ISO code for the currency the customer can be charged in for recurring billing purposes.
     public var currency: StripeCurrency?
     /// ID of the default payment source for the customer.
-    public var defaultSource: String?
+    @Expandable
+    public var defaultSource: StripeCard?
     /// When the customer’s latest invoice is billed by charging automatically, delinquent is true if the invoice’s latest charge is failed. When the customer’s latest invoice is billed by sending an invoice, delinquent is true if the invoice is not paid by its due date.
     public var delinquent: Bool?
     /// An arbitrary string attached to the object. Often useful for displaying to users.

--- a/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
+++ b/Sources/StripeKit/Core Resources/Customers/CustomerRoutes.swift
@@ -52,7 +52,8 @@ public protocol CustomerRoutes {
     ///
     /// - Parameter customer: The identifier of the customer to be retrieved.
     /// - Returns: A `StripeCustomer`.
-    func retrieve(customer: String) -> EventLoopFuture<StripeCustomer>
+    func retrieve(customer: String,
+                  expand: [String]?) -> EventLoopFuture<StripeCustomer>
     
     /// Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the source parameter, that becomes the customer’s active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the source parameter: for each of the customer’s current subscriptions, if the subscription bills automatically and is in the `past_due` state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the default_source for a customer will not trigger this behavior. \n This request accepts mostly the same arguments as the customer creation call.
     ///
@@ -143,8 +144,10 @@ extension CustomerRoutes {
                       taxIdData: taxIdData)
     }
     
-    public func retrieve(customer: String) -> EventLoopFuture<StripeCustomer> {
-        return retrieve(customer: customer)
+    public func retrieve(customer: String,
+                         expand: [String]? = nil) -> EventLoopFuture<StripeCustomer> {
+        return retrieve(customer: customer,
+                        expand: expand)
     }
     
     public func update(customer: String,
@@ -290,8 +293,15 @@ public struct StripeCustomerRoutes: CustomerRoutes {
         return apiHandler.send(method: .POST, path: customers, body: .string(body.queryParameters), headers: headers)
     }
     
-    public func retrieve(customer: String) -> EventLoopFuture<StripeCustomer> {
-        return apiHandler.send(method: .GET, path: self.customer + customer, headers: headers)
+    public func retrieve(customer: String,
+                         expand: [String]?) -> EventLoopFuture<StripeCustomer> {
+        var body: [String: Any] = [:]
+        
+        if let expand = expand {
+            body["expand"] = expand
+        }
+        
+        return apiHandler.send(method: .GET, path: self.customer + customer, body: .string(body.queryParameters), headers: headers)
     }
     
     public func update(customer: String,

--- a/Sources/StripeKit/Shared Models/StripeIdentifiable.swift
+++ b/Sources/StripeKit/Shared Models/StripeIdentifiable.swift
@@ -1,0 +1,70 @@
+//
+//  StripeIdentifiable.swift
+//  Stripe
+//
+//  Created by Alessio Buratti on 12.12.19.
+//
+//
+
+import NIO
+
+public protocol StripeExpandable: StripeModel {
+    var id: String { get }
+}
+
+extension StripeCustomer: StripeExpandable { }
+
+extension StripeCard: StripeExpandable { }
+
+
+@propertyWrapper
+public struct Expandable<Model: StripeExpandable>: StripeModel {
+    
+    private enum ExpandableState {
+        case unexpanded(String)
+        case expanded(Model)
+    }
+    
+    private var _state: ExpandableState
+    
+    public var id: String {
+        switch _state {
+        case let .unexpanded(id):
+            return id
+        case let .expanded(model):
+            return model.id
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        switch _state {
+        case let .unexpanded(id):
+            try id.encode(to: encoder)
+        case let .expanded(model):
+            try model.encode(to: encoder)
+        }
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            _state = try .unexpanded(String(from: decoder))
+        } catch DecodingError.typeMismatch(_, _) {
+            _state = try .expanded(Model(from: decoder))
+        } catch {
+            throw error
+        }
+    }
+    
+    public var wrappedValue: Model? {
+        switch _state {
+        case .unexpanded(_):
+            return nil
+        case let .expanded(model):
+            return model
+        }
+    }
+    
+    public var projectedValue: Expandable<Model> {
+        self
+    }
+}


### PR DESCRIPTION
Added the missing StripeTaxIDTypes as shown in the [Customer documentation](https://stripe.com/docs/api/customers/object#customer_object-tax_ids-data-type).

```Type of the tax ID, one of au_abn, ch_vat, eu_vat, in_gst, mx_rfc, no_vat, nz_gst, za_vat, or unknown```

