### PR TITLE
Updated Initializer to accept http client and event loop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 ### StripeKit is a Swift package used to communicate with the [Stripe](https://stripe.com) API for Server Side Swift Apps.
 
 ## Current supported version
-Version **3.0.0** of StripeKit supports the Stripe API version of **[2019-11-05](https://stripe.com/docs/upgrades#2019-11-05)**. 
+Version **4.0.0** of StripeKit supports the Stripe API version of **[2019-11-05](https://stripe.com/docs/upgrades#2019-11-05)**. 
 **You can check the releases page to use a version of StripeKit that meets your needs.**
 
 ## Installation
 To start using StripeKit, in your `Package.swift`, add the following
 
 ~~~~swift
-.package(url: "https://github.com/vapor-community/stripekit.git", from: "3.0.0")
+.package(url: "https://github.com/vapor-community/stripekit.git", from: "4.0.0")
 ~~~~
 
 ## Using the API
 Initialize the `StripeClient`
 
 ~~~~swift
-let elg = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-let stripe = StripeClient(eventLoop: elg, apiKey: "sk_12345")
+let httpClient = HTTPClient(..)
+let stripe = StripeClient(httpClient: httpClient, eventLoop: eventLoop, apiKey: "sk_12345")
 ~~~~
 
 And now you have acess to the APIs via `stripe`.

--- a/Sources/StripeKit/StripeClient.swift
+++ b/Sources/StripeKit/StripeClient.swift
@@ -92,11 +92,12 @@ public final class StripeClient {
     public var reportRuns: ReportRunRoutes
     public var reportTypes: ReportTypeRoutes
     
-    private let client: HTTPClient
-    
-    public init(eventLoop: EventLoopGroup, apiKey: String) {
-        client = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
-        let handler = StripeDefaultAPIHandler(httpClient: client, apiKey: apiKey)
+    /// Returns a StripeClient used to interact with the Stripe APIs.
+    /// - Parameter httpClient: An `HTTPClient`used to communicate wiith the Stripe API
+    /// - Parameter eventLoop: An `EventLoop` used to return an `EventLoopFuture` on.
+    /// - Parameter apiKey: A Stripe API key.
+    public init(httpClient: HTTPClient, eventLoop: EventLoop, apiKey: String) {
+        let handler = StripeDefaultAPIHandler(httpClient: httpClient, eventLoop: eventLoop, apiKey: apiKey)
         
         balances = StripeBalanceRoutes(apiHandler: handler)
         balanceTransactions = StripeBalanceTransactionRoutes(apiHandler: handler)
@@ -169,9 +170,5 @@ public final class StripeClient {
         
         reportRuns = StripeReportRunRoutes(apiHandler: handler)
         reportTypes = StripeReportTypeRoutes(apiHandler: handler)
-    }
-    
-    deinit {
-        try? client.syncShutdown()
     }
 }


### PR DESCRIPTION
This PR allows initializing a `StripeClient` with a preconfigured `HTTPClient` and a specified `EventLoop` to have internal API requests/work to be executed and have `EventLoopFuture`s returned on. 

```swift
let client = HTTPClient(...)
let stripe = StripeClient(httpClient: client, eventLoop: myEventLoop, apiKey: "sk_123")
```