### PR TITLE
Add hopped event loop convenience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,18 @@ None of the API calls throw errors. Instead each route returns a successful `Eve
 To use StripeKit with Vapor 4.x, add a simple extension on `Request`.
 ~~~swift
 extension Request {
+    private struct StripeKey: StorageKey {
+        typealias Value = StripeClient
+    }
+    
     public var stripe: StripeClient {
-        return StripeClient(httpClient: self.application.client.http, eventLoop: self.eventLoop, apiKey: "STRIPE_API_KEY")
+        if let existing = application.storage[StripeKey.self] {
+            return existing.hopped(to: self.eventLoop)
+        } else {
+            let new = StripeClient(httpClient: self.application.client.http, eventLoop: self.eventLoop, apiKey: "STRIPE_API_KEY")
+            self.application.storage[StripeKey.self] = new
+            return new
+        }
     }
 }
 

--- a/Sources/StripeKit/StripeClient.swift
+++ b/Sources/StripeKit/StripeClient.swift
@@ -97,12 +97,14 @@ public final class StripeClient {
     // MARK: - WEBHOOKS
     public var webhookEndpoints: WebhookEndpointRoutes
     
+    var handler: StripeAPIHandler
+    
     /// Returns a StripeClient used to interact with the Stripe APIs.
     /// - Parameter httpClient: An `HTTPClient`used to communicate wiith the Stripe API
     /// - Parameter eventLoop: An `EventLoop` used to return an `EventLoopFuture` on.
     /// - Parameter apiKey: A Stripe API key.
     public init(httpClient: HTTPClient, eventLoop: EventLoop, apiKey: String) {
-        let handler = StripeDefaultAPIHandler(httpClient: httpClient, eventLoop: eventLoop, apiKey: apiKey)
+        handler = StripeDefaultAPIHandler(httpClient: httpClient, eventLoop: eventLoop, apiKey: apiKey)
         
         balances = StripeBalanceRoutes(apiHandler: handler)
         balanceTransactions = StripeBalanceTransactionRoutes(apiHandler: handler)
@@ -179,5 +181,12 @@ public final class StripeClient {
         reportTypes = StripeReportTypeRoutes(apiHandler: handler)
         
         webhookEndpoints = StripeWebhookEndpointRoutes(apiHandler: handler)
+    }
+    
+    /// Hop to a new eventloop to execute requests on.
+    /// - Parameter eventLoop: The eventloop to execute requests on.
+    public func hopped(to eventLoop: EventLoop) -> StripeClient {
+        handler.eventLoop = eventLoop
+        return self
     }
 }

--- a/Sources/StripeKit/StripeClient.swift
+++ b/Sources/StripeKit/StripeClient.swift
@@ -97,7 +97,7 @@ public final class StripeClient {
     // MARK: - WEBHOOKS
     public var webhookEndpoints: WebhookEndpointRoutes
     
-    var handler: StripeAPIHandler
+    var handler: StripeDefaultAPIHandler
     
     /// Returns a StripeClient used to interact with the Stripe APIs.
     /// - Parameter httpClient: An `HTTPClient`used to communicate wiith the Stripe API

--- a/Sources/StripeKit/StripeRequest.swift
+++ b/Sources/StripeKit/StripeRequest.swift
@@ -38,11 +38,11 @@ extension StripeAPIHandler {
     }
 }
 
-public struct StripeDefaultAPIHandler: StripeAPIHandler {
+struct StripeDefaultAPIHandler: StripeAPIHandler {
     private let httpClient: HTTPClient
     private let apiKey: String
     private let decoder = JSONDecoder()
-    private let eventLoop: EventLoop
+    var eventLoop: EventLoop
 
     init(httpClient: HTTPClient, eventLoop: EventLoop, apiKey: String) {
         self.httpClient = httpClient


### PR DESCRIPTION
This PR adds a new method on `StripeClient` `hopped(to:...)` that makes sure all requests are executed on the given event loop.

For example in the context where event loops are changed we can safely reuse a stripe client without having to create a new client everytime. 
```swift
public var stripe: StripeClient {
        if let existing = serviceCache["stripe"] {
            return existing.hopped(to: currentEventloop)
        } else {
            let new = StripeClient(httpClient: httpClient, eventLoop: initialEventLoop, apiKey: "STRIPE_API_KEY")
            serviceCache["stripe"] = new
            return new
        }
    }
```